### PR TITLE
Add delimiter option

### DIFF
--- a/src/LatexTemplater.UnitTests/Templater.Tests.cs
+++ b/src/LatexTemplater.UnitTests/Templater.Tests.cs
@@ -34,7 +34,42 @@ public class Tests
             await File.WriteAllTextAsync(texFile, tex);
             await File.WriteAllTextAsync(yamlFile, yaml);
         
-            var result = await Templater.Execute(new CommandLineArguments(texFile, yamlFile), CancellationToken.None);
+            var result = await Templater.Execute(new CommandLineArguments(texFile, yamlFile, ["<<",">>"]), CancellationToken.None);
+            
+            result.Should().Be("hello\nThis is a string that will be inserted into the text file.\ngoodbye");
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, true);
+        }
+    }
+    
+    [Test]
+    public async Task BasicTest2()
+    {
+        var temporaryDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            Directory.CreateDirectory(temporaryDirectory);
+            var tex = 
+                """
+                hello
+                <<< my.cool.variable >>
+                goodbye
+                """;
+            var yaml =
+                """
+                my:
+                    cool:
+                        variable:
+                            "This is a string that will be inserted into the text file."
+                """;
+            var texFile = Path.Combine(temporaryDirectory, "tex.tex");
+            var yamlFile = Path.Combine(temporaryDirectory, "yaml.yaml");
+            await File.WriteAllTextAsync(texFile, tex);
+            await File.WriteAllTextAsync(yamlFile, yaml);
+        
+            var result = await Templater.Execute(new CommandLineArguments(texFile, yamlFile, ["<<<",">>"]), CancellationToken.None);
             
             result.Should().Be("hello\nThis is a string that will be inserted into the text file.\ngoodbye");
         }
@@ -81,7 +116,7 @@ public class Tests
             await File.WriteAllTextAsync(texBaseFile, texBase);
             await File.WriteAllTextAsync(yamlFile, yaml);
         
-            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile), CancellationToken.None);
+            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile, ["<<",">>"]), CancellationToken.None);
             
             result.Should().Be("I want to insert another tex into this file\nhello\nThis is a string that will be inserted into the text file.\ngoodbye\nOther stuff afterwards");
         }
@@ -127,7 +162,7 @@ public class Tests
             await File.WriteAllTextAsync(texBaseFile, texBase);
             await File.WriteAllTextAsync(yamlFile, yaml);
         
-            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile), CancellationToken.None);
+            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile, ["<<",">>"]), CancellationToken.None);
             
             result.Should().Be("I want to insert another tex into this file\nhello\nsomething\ngoodbye\nhello\nsomething2\ngoodbye\nhello\nsomething3\ngoodbye\nOther stuff afterwards");
         }
@@ -173,7 +208,7 @@ public class Tests
             await File.WriteAllTextAsync(texBaseFile, texBase);
             await File.WriteAllTextAsync(yamlFile, yaml);
         
-            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile), CancellationToken.None);
+            var result = await Templater.Execute(new CommandLineArguments(texBaseFile, yamlFile, ["<<",">>"]), CancellationToken.None);
             
             result.Should().Be("I want to insert another tex into this file\nhello\nsomething\ngoodbye\nhello\nsomething2\ngoodbye\nhello\nsomething3\ngoodbye\nOther stuff afterwards");
         }

--- a/src/LatexTemplater/CommandLineParser.cs
+++ b/src/LatexTemplater/CommandLineParser.cs
@@ -2,12 +2,12 @@ namespace LatexTemplater;
 
 public static class CommandLineParser
 {
-    private const string UsageString = "Usage: latemp <latexfile> <datafile> [-o <outputfile>]";
+    private const string UsageString = "Usage: latemp <latexfile> <datafile> [-o <outputfile>] [-d '<start><space><end>']";
 
     public static CommandLineArguments? Parse(string[] commandLineArgs)
     {
-        var outputFileNext = false;
-        string? latexFile = null, dataFile = null, outputFile = null;
+        bool outputFileNext = false, delimiterNext = false;
+        string? latexFile = null, dataFile = null, outputFile = null, delimiter = null;
         foreach (var arg in commandLineArgs)
         {
             if (outputFileNext)
@@ -16,12 +16,23 @@ public static class CommandLineParser
                 outputFile = arg;
                 continue;
             }
+            if (delimiterNext)
+            {
+                delimiterNext = false;
+                delimiter = arg;
+                continue;
+            }
             switch (arg)
             {
                 case "-h":
                 case "--help":
                     Console.WriteLine(UsageString);
                     return null;
+                case "-d":
+                    if (delimiter != null)
+                        throw new Exception("Delimiter already set.");
+                    delimiterNext = true;
+                    continue;
                 case "-o":
                     if (outputFile != null)
                         throw new Exception("Output file already set.");
@@ -52,9 +63,13 @@ public static class CommandLineParser
         }
         if (latexFile == null || dataFile == null) 
             throw new Exception($"Requires at least two arguments: {UsageString}");
+
+        var delimiters = delimiter?.Split(' ');
+        if (delimiters is not null and not { Length: 2 }) 
+            throw new Exception($"delimiters are not formatted correctly ('{delimiter}'): {UsageString}"); 
         
-        return new CommandLineArguments(latexFile, dataFile, outputFile);
+        return new CommandLineArguments(latexFile, dataFile, delimiters ?? ["<<",">>"], outputFile);
     }
 }
 
-public record CommandLineArguments(string latexFile, string dataFile, string? outputFile = null);
+public record CommandLineArguments(string latexFile, string dataFile, string[] delimiters, string? outputFile = null);

--- a/src/LatexTemplater/Program.cs
+++ b/src/LatexTemplater/Program.cs
@@ -25,5 +25,3 @@ catch (Exception e)
     Console.Error.WriteLine(e.Message);
     return -1;
 }
-
-// latemp /path/to/document.tex path/to/data.yaml -o /path/to/templated.tex


### PR DESCRIPTION
This makes the engine more generic as different text formats have might use specific combinations of characters so you can specify what delimits a variable injection.